### PR TITLE
fix: updaetd handler to match when not all of version is supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ const versionHandler = async ({ path }) => {
 
   try {
     const filesFound = await getLatestVersion(version)
-    const regex = new RegExp(`(${matches[0].substr(1)}){1}`, 'g')
+    const regex = new RegExp(`(${matches[5].substr(1)}){1}`, 'g')
     const key = filesFound.find(key => !!regex.exec(key))
 
     if (!key) {

--- a/index.test.js
+++ b/index.test.js
@@ -275,5 +275,77 @@ describe('versionHandler', () => {
     )
   })
 
+  it('Should return 302 when file found', async () => {
+    const mockListObjectV2 = jest.fn((bucketParams, callback) => {
+      callback(undefined, {
+        Contents: [
+          { Key: 'int/2.0.1/smbc-frontend-ie8.min.css' },
+          { Key: 'int/1.1.2/smbc-frontend-ie8.min.css' },
+          { Key: 'int/1.1.1/smbc-frontend-ie8.min.css' }
+        ]
+      })
+    })
+
+    AWS.S3 = jest.fn().mockImplementation(() => ({
+      listObjectsV2: mockListObjectV2
+    }))
+
+    const result = await handler({
+      path: '/int/1.1.1/smbc-frontend-ie8.min.css'
+    })
+    expect(result.statusCode).toBe(302)
+    expect(result.headers.Location).toContain(
+      '/int/1.1.1/smbc-frontend-ie8.min.css'
+    )
+  })
+
+  it('Should return 302 with latest major when file found', async () => {
+    const mockListObjectV2 = jest.fn((bucketParams, callback) => {
+      callback(undefined, {
+        Contents: [
+          { Key: 'int/2.4.4/smbc-frontend-ie8.min.css' },
+          { Key: 'int/1.4.0/smbc-frontend-ie8.min.css' },
+          { Key: 'int/1.1.2/smbc-frontend-ie8.min.css' }
+        ]
+      })
+    })
+
+    AWS.S3 = jest.fn().mockImplementation(() => ({
+      listObjectsV2: mockListObjectV2
+    }))
+
+    const result = await handler({
+      path: '/int/2/smbc-frontend-ie8.min.css'
+    })
+    expect(result.statusCode).toBe(302)
+    expect(result.headers.Location).toContain(
+      '/int/2.4.4/smbc-frontend-ie8.min.css'
+    )
+  })
+
+  it('Should return 302 with latest major and minor when file found', async () => {
+    const mockListObjectV2 = jest.fn((bucketParams, callback) => {
+      callback(undefined, {
+        Contents: [
+          { Key: 'int/2.4.8/smbc-frontend-ie8.min.css' },
+          { Key: 'int/2.4.3/smbc-frontend-ie8.min.css' },
+          { Key: 'int/2.4.2/smbc-frontend-ie8.min.css' }
+        ]
+      })
+    })
+
+    AWS.S3 = jest.fn().mockImplementation(() => ({
+      listObjectsV2: mockListObjectV2
+    }))
+
+    const result = await handler({
+      path: '/int/2.4/smbc-frontend-ie8.min.css'
+    })
+    expect(result.statusCode).toBe(302)
+    expect(result.headers.Location).toContain(
+      '/int/2.4.8/smbc-frontend-ie8.min.css'
+    )
+  })
+
   afterEach(() => jest.resetAllMocks())
 })

--- a/index.test.js
+++ b/index.test.js
@@ -275,30 +275,6 @@ describe('versionHandler', () => {
     )
   })
 
-  it('Should return 302 when file found', async () => {
-    const mockListObjectV2 = jest.fn((bucketParams, callback) => {
-      callback(undefined, {
-        Contents: [
-          { Key: 'int/2.0.1/smbc-frontend-ie8.min.css' },
-          { Key: 'int/1.1.2/smbc-frontend-ie8.min.css' },
-          { Key: 'int/1.1.1/smbc-frontend-ie8.min.css' }
-        ]
-      })
-    })
-
-    AWS.S3 = jest.fn().mockImplementation(() => ({
-      listObjectsV2: mockListObjectV2
-    }))
-
-    const result = await handler({
-      path: '/int/1.1.1/smbc-frontend-ie8.min.css'
-    })
-    expect(result.statusCode).toBe(302)
-    expect(result.headers.Location).toContain(
-      '/int/1.1.1/smbc-frontend-ie8.min.css'
-    )
-  })
-
   it('Should return 302 with latest major when file found', async () => {
     const mockListObjectV2 = jest.fn((bucketParams, callback) => {
       callback(undefined, {


### PR DESCRIPTION
### Description
Fix regex match on found files using provided version, this would not match when only major or major/minor provided due to regex using the provided version and not being able to match /1/ against /1.0.0/ if majoe was only supplied


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary