### PR TITLE
fix: updated path regex to support .woff/.tff

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ const versionHandler = async ({ path }) => {
   }
 
   const matches = path.match(
-    /^(\/(int|qa|stage|prod){1}\/?([0-9]+(\.[0-9]+){0,2})\/)(([\w\W]*).min.css|([\w\W]*).min.js){1}$/
+    /^(\/(int|qa|stage|prod){1}\/?([0-9]+(\.[0-9]+){0,2})\/)(([\w\W]*).min.css|([\w\W]*).min.js|([\w\W]*).woff|([\w\W]*).ttf){1}$/
   )
 
   // wrapped in promise as lambda requries a promise to be returned

--- a/index.test.js
+++ b/index.test.js
@@ -275,6 +275,50 @@ describe('versionHandler', () => {
     )
   })
 
+  it('Should return 302 when file found for .woff extenison', async () => {
+    const mockListObjectV2 = jest.fn((bucketParams, callback) => {
+      callback(undefined, {
+        Contents: [
+          { Key: 'int/1.1.1/assets/fonts/fa-solid-900.woff' }
+        ]
+      })
+    })
+
+    AWS.S3 = jest.fn().mockImplementation(() => ({
+      listObjectsV2: mockListObjectV2
+    }))
+
+    const result = await handler({
+      path: '/int/1/assets/fonts/fa-solid-900.woff'
+    })
+    expect(result.statusCode).toBe(302)
+    expect(result.headers.Location).toContain(
+      '/int/1.1.1/assets/fonts/fa-solid-900.woff'
+    )
+  })
+
+  it('Should return 302 when file found for .tff extenison', async () => {
+    const mockListObjectV2 = jest.fn((bucketParams, callback) => {
+      callback(undefined, {
+        Contents: [
+          { Key: 'int/1.1.1/assets/fonts/fa-solid-900.ttf' }
+        ]
+      })
+    })
+
+    AWS.S3 = jest.fn().mockImplementation(() => ({
+      listObjectsV2: mockListObjectV2
+    }))
+
+    const result = await handler({
+      path: '/int/1/assets/fonts/fa-solid-900.ttf'
+    })
+    expect(result.statusCode).toBe(302)
+    expect(result.headers.Location).toContain(
+      '/int/1.1.1/assets/fonts/fa-solid-900.ttf'
+    )
+  })
+
   it('Should return 302 with latest major when file found', async () => {
     const mockListObjectV2 = jest.fn((bucketParams, callback) => {
       callback(undefined, {


### PR DESCRIPTION
### Description
Updated regex on path test to allow for .woff and .tff file extensions

This only appears to be an issue on IE when it tries to resolve the assets from within min.css


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary